### PR TITLE
fix: animation fade out before fade in

### DIFF
--- a/components/magicEightBallComponents/MagicEightBallMainMenu.js
+++ b/components/magicEightBallComponents/MagicEightBallMainMenu.js
@@ -38,10 +38,12 @@ class MagicEightBallMainMenu extends Component {
 
   submitQuestion = () => {
     const kevinsThoughtMachine = new KevinsThoughtMachine()
-    const answer = kevinsThoughtMachine.getResponse().answer
     this.setState(() => ({
-      answer,
-    }))
+      answer: null
+    }), () => {
+      const answer = kevinsThoughtMachine.getResponse().answer
+      this.setState(() => ({ answer }));
+    })
   }
   reset = () => {
     Keyboard.dismiss()


### PR DESCRIPTION
FIxed the animation not working after the 1st answer.

All I had to do was **fade-out** the answer that was displaying before attempting to **fade-in** again (the control flag was this.state.answer, which I alternated from null back to a new answer)